### PR TITLE
circleCIにschema:loadではなくmigrateしてもらう

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+database:
+  override:
+    - bundle exec rake db:create db:migrate db:seed --trace


### PR DESCRIPTION
## 背景

デフォルトだとCircleCIは rake db:migrateではなく rake schema:loadする。そのあたりでエラーがでていたっぽいのでmigrateしてもらうように変更
