### PR TITLE
acceptとdestroyのinterfaceがイケてなかった

### DIFF
--- a/app/controllers/api/group_users_controller.rb
+++ b/app/controllers/api/group_users_controller.rb
@@ -1,7 +1,7 @@
 class Api::GroupUsersController < ApplicationController
   before_action :authenticate!
   before_action :set_group
-  before_action :set_group_user, only: %i(accept destroy)
+  before_action :set_group_user, only: %i(destroy)
 
   def index
     render json: @group.users.as_json(group_id: @group.id), status: :ok
@@ -24,8 +24,8 @@ class Api::GroupUsersController < ApplicationController
   end
 
   def accept
-    if @group_user.update(status: 'active')
-      render json: @group_user, status: :ok
+    if @group.group_users.first.update(status: 'active')
+      render json: @group.group_users.first, status: :ok
     else
       render json: {error: "グループの参加に失敗しました"}, status: :internal_server_error
     end
@@ -33,18 +33,18 @@ class Api::GroupUsersController < ApplicationController
 
   private
 
-  def set_group_user
-    @group_user = @user.group_users.find_by(id: params[:id])
-    unless @group_user.present?
-      render json: {error: "指定されたIDのグループユーザが見つかりません"}, status: :bad_request
-      return
-    end
-  end
-
   def set_group
     @group = @user.groups.find_by(id: params[:group_id])
     unless @group.present?
       render json: {error: "指定されたIDのグループが見つかりません"}, status: :bad_request
+      return
+    end
+  end
+
+  def set_group_user
+    @group_user = @group.group_users.find_by(user_id: params[:id])
+    unless @group_user.present?
+      render json: {error: "グループユーザが見つかりません"}, status: :bad_request
       return
     end
   end

--- a/app/controllers/api/group_users_controller.rb
+++ b/app/controllers/api/group_users_controller.rb
@@ -1,7 +1,7 @@
 class Api::GroupUsersController < ApplicationController
   before_action :authenticate!
   before_action :set_group
-  before_action :set_group_user, only: %i(destroy)
+  before_action :set_group_user, only: %i(accept destroy)
 
   def index
     render json: @group.users.as_json(group_id: @group.id), status: :ok
@@ -24,8 +24,8 @@ class Api::GroupUsersController < ApplicationController
   end
 
   def accept
-    if @group.group_users.first.update(status: 'active')
-      render json: @group.group_users.first, status: :ok
+    if @group_user.update(status: 'active')
+      render json: @group_user, status: :ok
     else
       render json: {error: "グループの参加に失敗しました"}, status: :internal_server_error
     end
@@ -42,7 +42,9 @@ class Api::GroupUsersController < ApplicationController
   end
 
   def set_group_user
-    @group_user = @group.group_users.find_by(user_id: params[:id])
+    user_id = params[:id] ? params[:id] : @user.id
+
+    @group_user = @group.group_users.find_by(user_id: user_id)
     unless @group_user.present?
       render json: {error: "グループユーザが見つかりません"}, status: :bad_request
       return

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
       end
       resources :groups do
         resources :users, controller: 'group_users', only: %i(index create destroy) do
-          member do
+          collection do
             patch :accept
           end
         end

--- a/spec/requests/group_members_spec.rb
+++ b/spec/requests/group_members_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe 'GroupUsers', type: :request do
       let!(:group_user) { create(:group_user, user_id: sign_in_user.id, group_id: group.id) }
 
       before do
-        patch accept_api_group_user_path(group_id: group.id, id: group_user.id), {}, env
+        patch accept_api_group_users_path(group_id: group.id), {}, env
         @json = JSON.parse(response.body)
       end
 
@@ -108,7 +108,7 @@ RSpec.describe 'GroupUsers', type: :request do
       let!(:group_user) { create(:group_user, user_id: user_1.id, group_id: group.id) }
 
       before do
-        patch accept_api_group_user_path(group_id: group.id, id: group_user.id), {}, env
+        patch accept_api_group_users_path(group_id: group.id, id: group_user.id), {}, env
       end
 
       example '400が返ってくること' do
@@ -123,7 +123,7 @@ RSpec.describe 'GroupUsers', type: :request do
       let!(:group_user) { create(:group_user, user_id: sign_in_user.id, group_id: group.id) }
 
       before do
-        delete api_group_user_path(group_id: group.id, id: group_user.id), {}, env
+        delete api_group_user_path(group_id: group.id, id: sign_in_user.id), {}, env
       end
 
       example '204が返ってくること' do
@@ -137,7 +137,7 @@ RSpec.describe 'GroupUsers', type: :request do
       let!(:group_user) { create(:group_user, user_id: user_1.id, group_id: group.id) }
 
       before do
-        delete api_group_user_path(group_id: group.id, id: group_user.id), {}, env
+        delete api_group_user_path(group_id: group.id, id: sign_in_user.id), {}, env
       end
 
       example '400が返ってくること' do


### PR DESCRIPTION
## やったこと
- acceptをmemberからcollectionに変えた
  /api/v1/groups/:group_id/users/:id/accept
  ↓
  /api/v1/groups/:group_id/users/accept
- destroy（多分今回のリリースでは使われない。追放機能？）のidの指定をgroup_user_id -> user_idにした
- テストの修正
