### PR TITLE
エラーメッセージを適切に返すようにした

### DIFF
--- a/app/controllers/api/group_users_controller.rb
+++ b/app/controllers/api/group_users_controller.rb
@@ -21,14 +21,14 @@ class Api::GroupUsersController < ApplicationController
     render json: @group, status: :ok
 
     rescue ActiveRecord::RecordInvalid => invalid
-      render json: {message: "メンバーの追加に失敗しました", errors: @group_user.errors.full_messages}, status: :internal_server_error
+      render json: {message: "メンバーの追加に失敗しました", errors: @group_user.errors.messages}, status: :internal_server_error
   end
 
   def destroy
     if @group_user.destroy
       render json: @group_user, status: :no_content
     else
-      render json: {error: "グループの退会に失敗しました"}, status: :internal_server_error
+      render json: {message: "グループの退会に失敗しました", errors: @group_user.errors.messages}, status: :internal_server_error
     end
   end
 
@@ -36,7 +36,7 @@ class Api::GroupUsersController < ApplicationController
     if @group_user.update(status: 'active')
       render json: @group_user, status: :ok
     else
-      render json: {error: "グループの参加に失敗しました"}, status: :internal_server_error
+      render json: {message: "グループの参加に失敗しました", errors: @group_user.errors.messages}, status: :internal_server_error
     end
   end
 
@@ -45,7 +45,7 @@ class Api::GroupUsersController < ApplicationController
   def set_group
     @group = @user.groups.find_by(id: params[:group_id])
     unless @group.present?
-      render json: {error: "指定されたIDのグループが見つかりません"}, status: :bad_request
+      render json: {message: "指定されたIDのグループが見つかりません"}, status: :bad_request
       return
     end
   end
@@ -55,7 +55,7 @@ class Api::GroupUsersController < ApplicationController
 
     @group_user = @group.group_users.find_by(user_id: user_id)
     unless @group_user.present?
-      render json: {error: "グループユーザが見つかりません"}, status: :bad_request
+      render json: {message: "グループユーザが見つかりません"}, status: :bad_request
       return
     end
   end

--- a/app/controllers/api/groups_controller.rb
+++ b/app/controllers/api/groups_controller.rb
@@ -22,7 +22,7 @@ class Api::GroupsController < ApplicationController
       render json: @group, status: :ok
 
     rescue ActiveRecord::RecordInvalid => invalid
-      render json: invalid.record.errors.full_messages, status: :internal_server_error
+      render json: {message: "グループの作成に成功しました" ,errors: invalid.record.errors.messages}, status: :internal_server_error
     end
   end
 
@@ -30,7 +30,7 @@ class Api::GroupsController < ApplicationController
     if @group.update(group_params)
       render json: @group, status: :ok
     else
-      render json: {error: "グループの更新に失敗しました"}, status: :internal_server_error
+      render json: {message: "グループの更新に失敗しました", errors: @group.errors.messages}, status: :internal_server_error
     end
   end
 
@@ -38,7 +38,7 @@ class Api::GroupsController < ApplicationController
     if @group.destroy
       render json: @group, status: :ok
     else
-      render json: {error: "グループの削除に失敗しました"}, status: :internal_server_error
+      render json: {message: "グループの削除に失敗しました", errors: @group.errors.messages}, status: :internal_server_error
     end
   end
 
@@ -47,7 +47,7 @@ class Api::GroupsController < ApplicationController
   def set_group
     @group = @user.groups.find_by(id: params[:id])
     unless @group.present?
-      render json: {error: "指定されたIDのグループが見つかりません"}, status: :not_found
+      render json: {message: "指定されたIDのグループが見つかりません"}, status: :not_found
       return
     end
   end

--- a/app/controllers/api/passwords_controller.rb
+++ b/app/controllers/api/passwords_controller.rb
@@ -5,12 +5,17 @@ class Api::PasswordsController < ApplicationController
 
   def update
     @user.password = params[:new_password]
+    unless @user.valid?(:reset_password)
+      render json: {message: "パスワードの更新に失敗しました", errors: @user.errors.messages}, status: :bad_request
+      return
+    end
+
     @user.hash_password
 
     if @user.save
       render json: @user, status: :ok
     else
-      render json: {error: "パスワードの更新に失敗しました"}, status: :internal_server_error
+      render json: {message: "パスワードの更新に失敗しました", errors: @user.errors.messages}, status: :internal_server_error
     end
   end
 
@@ -18,13 +23,13 @@ class Api::PasswordsController < ApplicationController
 
   def verify_old_password
     unless @user.authoricate(params[:password].strip)
-      render json: {error: "パスワードが正しくありません"}, status: :bad_request
+      render json: {message: "パスワードが正しくありません"}, status: :bad_request
     end
   end
 
   def verify_password_confirmation
     unless params[:new_password] == params[:new_password_confirmation]
-      render json: {error: "新しいパスワードと確認用パスワードが一致していません"}, status: :bad_request
+      render json: {message: "新しいパスワードと確認用パスワードが一致していません"}, status: :bad_request
     end
   end
 end

--- a/app/controllers/api/payments_controller.rb
+++ b/app/controllers/api/payments_controller.rb
@@ -38,13 +38,13 @@ class Api::PaymentsController < ApplicationController
     end
 
   rescue ActiveRecord::RecordInvalid => invalid
-    render json: invalid.record.errors.full_messages, status: :internal_server_error
+    render json: {message: "支払いの作成に失敗しました", errors: invalid.record.errors.messages}, status: :internal_server_error
   end
 
 
   def update
     unless @payment.paid_user.id == @user.id
-      render json: {errors: "権限のない操作です"}, status: :forbidden
+      render json: {message: "権限のない操作です"}, status: :forbidden
       return
     end
 
@@ -79,19 +79,19 @@ class Api::PaymentsController < ApplicationController
     end
 
   rescue ActiveRecord::RecordInvalid => invalid
-    render json: invalid.record.errors.full_messages, status: :internal_server_error
+    render json: {message: "支払いの作成に失敗しました", errors: invalid.record.errors.messages}, status: :internal_server_error
   end
 
   def destroy
     unless @payment.paid_user.id == @user.id
-      render json: {errors: "権限のない操作です"}, status: :forbidden
+      render json: {message: "権限のない操作です"}, status: :forbidden
       return
     end
 
     if @payment.update(deleted_at: Time.now)
       render json: @payment, status: :ok
     else
-      render json: {errors: "精算の削除に失敗しました"}, status: :internal_server_error
+      render json: {message: "支払いの削除に失敗しました", errors: @payment.errors.messages}, status: :internal_server_error
     end
   end
 
@@ -99,7 +99,7 @@ class Api::PaymentsController < ApplicationController
 
   def deny_first_and_last_params
     if params[:first_id].present? && params[:last_id].present?
-      render json: {error: "first_idかlast_idはどちらか1つしか指定できません"}, status: :bad_request
+      render json: {message: "first_idかlast_idはどちらか1つしか指定できません"}, status: :bad_request
       return
     end
   end
@@ -107,21 +107,21 @@ class Api::PaymentsController < ApplicationController
   def set_payment
     @payment = Payment.find_by(id: params[:id])
     unless @payment.present? && @user.groups.exists?(id: @payment.group_id)
-      render json: {error: "指定されたIDの精算が見つかりません"}, status: :not_found
+      render json: {message: "指定されたIDの精算が見つかりません"}, status: :not_found
       return
     end
   end
 
   def set_group
     if params['group_id'].blank?
-      render json: {errors: "グループidが入力されていません"}, status: :bad_request
+      render json: {message: "グループidが入力されていません"}, status: :bad_request
       return
     end
 
     @group = @user.groups.find_by(id: params['group_id'])
 
     unless @group.present?
-      render json: {error: "指定されたIDのグループが見つかりません"}, status: :bad_request
+      render json: {message: "指定されたIDのグループが見つかりません"}, status: :bad_request
       return
     end
   end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -29,7 +29,7 @@ class Api::UsersController < ApplicationController
     if @user.update(user_params)
       render json: @user, status: :ok
     else
-      render json: {message: 'ユーザーの更新に失敗しました', errors: @user.errors.full_messages}, status: :internal_server_error
+      render json: {message: 'ユーザーの更新に失敗しました', errors: @user.errors.messages}, status: :internal_server_error
     end
   end
 
@@ -58,7 +58,7 @@ class Api::UsersController < ApplicationController
     if @user.update(token: nil)
       render json: @user, status: :ok
     else
-      render json: {message: "サインアウトに失敗しました", errors: @user.errors.full_messages}, status: :internal_server_error
+      render json: {message: "サインアウトに失敗しました", errors: @user.errors.messages}, status: :internal_server_error
     end
   end
 

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -5,7 +5,7 @@ class Api::UsersController < ApplicationController
   def index
     # バリデーション
     if params['group_id'].blank?
-      render json: {error: "グループidが入力されていません"}, status: :internal_server_error
+      render json: {message: "グループidが入力されていません"}, status: :internal_server_error
       return
     end
     render json: Group.find(params['group_id']).users, status: :ok
@@ -21,7 +21,7 @@ class Api::UsersController < ApplicationController
     if @user.save
       render json: @user, status: :ok
     else
-      render json: {error: "ユーザの作成に失敗しました"}, status: :internal_server_error
+      render json: {message: 'ユーザーの作成に失敗しました', errors: @user.errors.messages }, status: :internal_server_error
     end
   end
 
@@ -29,7 +29,7 @@ class Api::UsersController < ApplicationController
     if @user.update(user_params)
       render json: @user, status: :ok
     else
-      render json: {error: "ユーザの更新に失敗しました"}, status: :internal_server_error
+      render json: {message: 'ユーザーの更新に失敗しました', errors: @user.errors.full_messages}, status: :internal_server_error
     end
   end
 
@@ -41,7 +41,7 @@ class Api::UsersController < ApplicationController
     #usernameとpasswordを受け取って、正しければ、tokenを再生成して、DBに上書く&返す
     @user = User.find_by(account: params[:account].strip)
     if @user.blank?
-      render json: {error: "アカウント名かパスワードが正しくありません"}, status: :unauthorized
+      render json: {message: "アカウント名かパスワードが正しくありません"}, status: :unauthorized
       return
     end
 
@@ -50,7 +50,7 @@ class Api::UsersController < ApplicationController
       @user.save!
       render json: @user, status: :ok
     else
-      render json: {error: "アカウント名かパスワードが正しくありません"}, status: :unauthorized
+      render json: {message: "アカウント名かパスワードが正しくありません"}, status: :unauthorized
     end
   end
 
@@ -58,7 +58,7 @@ class Api::UsersController < ApplicationController
     if @user.update(token: nil)
       render json: @user, status: :ok
     else
-      render json: {error: "サインアウトに失敗しました"}, status: :internal_server_error
+      render json: {message: "サインアウトに失敗しました", errors: @user.errors.full_messages}, status: :internal_server_error
     end
   end
 
@@ -78,7 +78,7 @@ class Api::UsersController < ApplicationController
   def set_user
     @user = User.find_by(id: params[:id])
     unless @user.present?
-      render json: {error: "指定されたIDのユーザが見つかりません"}, status: :not_found
+      render json: {message: "指定されたIDのユーザーが見つかりません"}, status: :not_found
       return
     end
   end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -7,10 +7,10 @@ class Payment < ActiveRecord::Base
   has_many :participant_reference, class_name: 'Participant'
   has_many :participants, class_name: 'User', through: :participant_reference, source: :user
 
-  validates :amount, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :amount, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0, allow_blank: true }
   validates :event, presence: true, length: {maximum: 30}, unless: :is_repayment
   validates :description, presence: true, length: {maximum: 100}, unless: :is_repayment
-  validates :date, presence: true, date: true
+  validates :date, presence: true, date: { allow_blank: true }
   validates :group_id, presence: true
   validates :paid_user_id, presence: true, user_id: true, group_member: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,9 +14,9 @@ class User < ActiveRecord::Base
   # validation
   validates :account, presence: true, uniqueness: true, length: {maximum: 30}
   validates :username, presence: true, length: {maximum: 30}
-  validates :email, presence: true, format: { with: VALID_EMAIL_REGEX }, uniqueness: true, length: {maximum: 256}
+  validates :email, presence: true, format: { with: VALID_EMAIL_REGEX, allow_blank: true }, uniqueness: true, length: {maximum: 256}
   validates :password, presence: true
-  validates :password, length: {minimum: 7, maximum: 20}, on: :create
+  validates :password, length: {minimum: 7, maximum: 20, allow_blank: true}, on: :create
   validates :role, numericality: { only_integer: true }
 
   before_create :hash_password

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,7 @@ class User < ActiveRecord::Base
   validates :username, presence: true, length: {maximum: 30}
   validates :email, presence: true, format: { with: VALID_EMAIL_REGEX, allow_blank: true }, uniqueness: true, length: {maximum: 256}
   validates :password, presence: true
-  validates :password, length: {minimum: 7, maximum: 20, allow_blank: true}, on: :create
+  validates :password, length: {minimum: 7, maximum: 20, allow_blank: true}, on: [:create, :reset_password]
   validates :role, numericality: { only_integer: true }
 
   before_create :hash_password

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,7 +25,7 @@ module Yoshinani
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    # config.i18n.default_locale = :de
+    config.i18n.default_locale = :ja
 
     # add custom validators path
     config.autoload_paths += Dir["#{config.root}/app/validators"]

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,202 @@
+---
+ja:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: "バリデーションに失敗しました: %{errors}"
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+  date:
+    abbr_day_names:
+    - 日
+    - 月
+    - 火
+    - 水
+    - 木
+    - 金
+    - 土
+    abbr_month_names:
+    -
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 日曜日
+    - 月曜日
+    - 火曜日
+    - 水曜日
+    - 木曜日
+    - 金曜日
+    - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+    -
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 約1時間
+        other: 約%{count}時間
+      about_x_months:
+        one: 約1ヶ月
+        other: 約%{count}ヶ月
+      about_x_years:
+        one: 約1年
+        other: 約%{count}年
+      almost_x_years:
+        one: 1年弱
+        other: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_minutes:
+        one: 1分以内
+        other: "%{count}分未満"
+      less_than_x_seconds:
+        one: 1秒以内
+        other: "%{count}秒未満"
+      over_x_years:
+        one: 1年以上
+        other: "%{count}年以上"
+      x_days:
+        one: 1日
+        other: "%{count}日"
+      x_minutes:
+        one: 1分
+        other: "%{count}分"
+      x_months:
+        one: 1ヶ月
+        other: "%{count}ヶ月"
+      x_seconds:
+        one: 1秒
+        other: "%{count}秒"
+    prompts:
+      day: 日
+      hour: 時
+      minute: 分
+      month: 月
+      second: 秒
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: "%{attribute}を受諾してください"
+      blank: "%{attribute}を入力してください"
+      present: "%{attribute}は入力しないでください"
+      confirmation: "%{attribute}と%{attribute}の入力が一致しません"
+      empty: "%{attribute}を入力してください"
+      equal_to: "%{attribute}は%{count}にしてください"
+      even: "%{attribute}は偶数にしてください"
+      exclusion: "%{attribute}は予約されています"
+      greater_than: "%{attribute}は%{count}より大きい値にしてください"
+      greater_than_or_equal_to: "%{attribute}は%{count}以上の値にしてください"
+      inclusion: "%{attribute}は一覧にありません"
+      invalid: "%{attribute}は不正な値です"
+      less_than: "%{attribute}は%{count}より小さい値にしてください"
+      less_than_or_equal_to: "%{attribute}は%{count}以下の値にしてください"
+      model_invalid: "バリデーションに失敗しました: %{errors}"
+      not_a_number: "%{attribute}は数値で入力してください"
+      not_an_integer: "%{attribute}は整数で入力してください"
+      odd: "%{attribute}は奇数にしてください"
+      required: "%{attribute}を入力してください"
+      taken: "%{attribute}はすでに存在します"
+      too_long: "%{attribute}は%{count}文字以内で入力してください"
+      too_short: "%{attribute}は%{count}文字以上で入力してください"
+      wrong_length: "%{attribute}は%{count}文字で入力してください"
+      other_than: "%{attribute}は%{count}以外の値にしてください"
+    template:
+      body: 次の項目を確認してください
+      header:
+        one: "%{model}にエラーが発生しました"
+        other: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          gb: ギガバイト
+          kb: キロバイト
+          mb: メガバイト
+          tb: テラバイト
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: と
+      two_words_connector: と
+      words_connector: と
+  time:
+    am: 午前
+    formats:
+      default: "%Y/%m/%d %H:%M:%S"
+      long: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      short: "%y/%m/%d %H:%M"
+    pm: 午後

--- a/config/locales/models.ja.yml
+++ b/config/locales/models.ja.yml
@@ -1,0 +1,53 @@
+ja:
+  activerecord:
+    timestamps: &timestamps
+      created_at: 登録日時
+      updated_at: 最終更新日時
+    models:
+      group: グループ
+      group_user: グループユーザー
+      participant: 参加者
+      payment: 支払い
+      total: 収支
+      user: ユーザー
+    attributes:
+      group:
+        id: グループID
+        name: 名前
+        desctription: 説明
+        <<: *timestamps
+      group_user:
+        id: グループユーザーID
+        role: ロール
+        status: ステータス
+        group_id: activerecord.models.group.id
+        user_id: activerecord.models.user.id
+        <<: *timestamps
+      participant:
+        payment_id: activerecord.models.payment.id
+        user_id: activerecord.models.user.id
+      payment:
+        id: 支払いID
+        amount: 金額
+        event: イベント
+        desctription: 説明
+        date: 日付
+        paid_user_id: 立替者の会員番号
+        is_repayment: 精算フラグ
+        deleted_at: 削除日時
+        group_id: activerecord.models.group.id
+        <<: *timestamps
+      total:
+        paid: 立替金額
+        to_pay: 立替てもらった金額
+        group_id: activerecord.models.group.id
+        user_id: activerecord.models.user.id
+        <<: *timestamps
+      user:
+        id: 会員番号
+        account: アカウント名
+        username: ユーザー名
+        email: メールアドレス
+        password: パスワード
+        role: ロール
+        <<: *timestamps

--- a/config/locales/models.ja.yml
+++ b/config/locales/models.ja.yml
@@ -20,28 +20,28 @@ ja:
         id: グループユーザーID
         role: ロール
         status: ステータス
-        group_id: activerecord.models.group.id
-        user_id: activerecord.models.user.id
+        group_id: :activerecord.models.group.id
+        user_id: :activerecord.models.user.id
         <<: *timestamps
       participant:
-        payment_id: activerecord.models.payment.id
-        user_id: activerecord.models.user.id
+        payment_id: :activerecord.models.payment.id
+        user_id: :activerecord.models.user.id
       payment:
         id: 支払いID
         amount: 金額
         event: イベント
-        desctription: 説明
+        description: 説明
         date: 日付
         paid_user_id: 立替者の会員番号
         is_repayment: 精算フラグ
         deleted_at: 削除日時
-        group_id: activerecord.models.group.id
+        group_id: :グループID
         <<: *timestamps
       total:
         paid: 立替金額
         to_pay: 立替てもらった金額
-        group_id: activerecord.models.group.id
-        user_id: activerecord.models.user.id
+        group_id: :activerecord.models.group.id
+        user_id: :activerecord.models.user.id
         <<: *timestamps
       user:
         id: 会員番号

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Group do
+  describe 'validation' do
+    describe '#name' do
+      let(:group) { Group.new(name: name) }
+
+      context '正常系' do
+        let(:name) { '幻影旅団' }
+
+        it { expect(group.errors_on(:name)).to be_empty }
+      end
+
+      context '正常系' do
+        let(:name) { nil }
+
+        it { expect(group.errors_on(:name)).to include('名前を入力してください') }
+      end
+    end
+  end
+end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -14,19 +14,19 @@ RSpec.describe Payment do
       context '空の場合' do
         let(:amount) { nil }
 
-        it { expect(payment.errors_on(:amount)).to include('can\'t be blank') }
+        it { expect(payment.errors_on(:amount)).to include('金額を入力してください') }
       end
 
       context '負の値の場合' do
         let(:amount) { -10000 }
 
-        it { expect(payment.errors_on(:amount)).to include('must be greater than or equal to 0') }
+        it { expect(payment.errors_on(:amount)).to include('金額は0以上の値にしてください') }
       end
 
       context 'integer以外の値の場合' do
         let(:amount) { 'たくさん' }
 
-        it { expect(payment.errors_on(:amount)).to include('is not a number') }
+        it { expect(payment.errors_on(:amount)).to include('金額は数値で入力してください') }
       end
     end
 
@@ -42,7 +42,7 @@ RSpec.describe Payment do
       context '空の場合' do
         let(:event) { nil }
 
-        it { expect(payment.errors_on(:event)).to include('can\'t be blank') }
+        it { expect(payment.errors_on(:event)).to include('イベントを入力してください') }
       end
 
       context '30文字の場合' do
@@ -54,7 +54,7 @@ RSpec.describe Payment do
       context '31文字の場合' do
         let(:event) { 'あ' * 31 }
 
-        it { expect(payment.errors_on(:event)).to include('is too long (maximum is 30 characters)')}
+        it { expect(payment.errors_on(:event)).to include('イベントは30文字以内で入力してください')}
       end
 
       context '精算の場合' do
@@ -78,7 +78,7 @@ RSpec.describe Payment do
       context '空の場合' do
         let(:description) { nil }
 
-        it { expect(payment.errors_on(:description)).to include('can\'t be blank') }
+        it { expect(payment.errors_on(:description)).to include('説明を入力してください') }
       end
 
       context '100文字の場合' do
@@ -90,7 +90,7 @@ RSpec.describe Payment do
       context '101文字の場合' do
         let(:description) { 'あ' * 101 }
 
-        it { expect(payment.errors_on(:description)).to include('is too long (maximum is 100 characters)')}
+        it { expect(payment.errors_on(:description)).to include('説明は100文字以内で入力してください')}
       end
 
       context '精算の場合' do
@@ -114,13 +114,13 @@ RSpec.describe Payment do
       context '空の場合' do
         let(:date) { nil }
 
-        it { expect(payment.errors_on(:date)).to include('can\'t be blank') }
+        it { expect(payment.errors_on(:date)).to include('日付を入力してください') }
       end
 
       context 'date以外の値の場合' do
         let(:date) { 'ふがふが' }
 
-        it { expect(payment.errors_on(:date)).to include('is not a date') }
+        it { expect(payment.errors_on(:date)).to include('は日付ではありません') }
       end
     end
 
@@ -136,7 +136,7 @@ RSpec.describe Payment do
       context '空の場合' do
         let(:group_id) { nil }
 
-        it { expect(payment.errors_on(:group_id)).to include('can\'t be blank') }
+        it { expect(payment.errors_on(:group_id)).to include('Groupを入力してください') }
       end
     end
 
@@ -159,7 +159,7 @@ RSpec.describe Payment do
       context '空の場合' do
         let(:paid_user_id) { nil }
 
-        it { expect(payment.errors_on(:paid_user_id)).to include('can\'t be blank') }
+        it { expect(payment.errors_on(:paid_user_id)).to include('立替者の会員番号を入力してください') }
       end
 
       context 'paid_user_idに紐づくuserが存在しない場合' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe User do
       context '空の場合' do
         let(:account) { nil }
 
-        it { expect(user.errors_on(:account)).to include('can\'t be blank') }
+        it { expect(user.errors_on(:account)).to include('アカウント名を入力してください') }
       end
 
       context '重複する値の場合' do
@@ -24,7 +24,7 @@ RSpec.describe User do
           create(:user, account: 'amuro_rei')
         end
 
-        it { expect(user.errors_on(:account)).to include('has already been taken') }
+        it { expect(user.errors_on(:account)).to include('アカウント名はすでに存在します') }
       end
 
       context '30文字の場合' do
@@ -36,7 +36,7 @@ RSpec.describe User do
       context '31文字の場合' do
         let(:account) { 'hogehogehogehogehogehogehogehog' }
 
-        it { expect(user.errors_on(:account)).to include('is too long (maximum is 30 characters)') }
+        it { expect(user.errors_on(:account)).to include('アカウント名は30文字以内で入力してください') }
       end
     end
 
@@ -52,7 +52,7 @@ RSpec.describe User do
       context '空の場合' do
         let(:username) { nil }
 
-        it { expect(user.errors_on(:username)).to include('can\'t be blank') }
+        it { expect(user.errors_on(:username)).to include('ユーザー名を入力してください') }
       end
 
       context '30文字の場合' do
@@ -64,7 +64,7 @@ RSpec.describe User do
       context '31文字の場合' do
         let(:username) { 'hogehogehogehogehogehogehogehog' }
 
-        it { expect(user.errors_on(:username)).to include('is too long (maximum is 30 characters)') }
+        it { expect(user.errors_on(:username)).to include('ユーザー名は30文字以内で入力してください') }
       end
     end
 
@@ -80,7 +80,7 @@ RSpec.describe User do
       context '空の場合' do
         let(:email) { nil }
 
-        it { expect(user.errors_on(:email)).to include('can\'t be blank') }
+        it { expect(user.errors_on(:email)).to include('メールアドレスを入力してください') }
       end
 
       context '重複する値の場合' do
@@ -90,19 +90,19 @@ RSpec.describe User do
           create(:user, email: 'gandum-rx78-2@example.com')
         end
 
-        it { expect(user.errors_on(:email)).to include('has already been taken') }
+        it { expect(user.errors_on(:email)).to include('メールアドレスはすでに存在します') }
       end
 
       context '不正な値の場合' do
         let(:email) { 'gandum-rx78-2@zakuzaku' }
 
-        it { expect(user.errors_on(:email)).to include('is invalid') }
+        it { expect(user.errors_on(:email)).to include('メールアドレスは不正な値です') }
       end
 
       context '256文字以上の場合' do
         let(:email) { 'x' * 256 + '@example.com' }
 
-        it { expect(user.errors_on(:email)).to include('is too long (maximum is 256 characters)') }
+        it { expect(user.errors_on(:email)).to include('メールアドレスは256文字以内で入力してください') }
       end
     end
 
@@ -118,13 +118,13 @@ RSpec.describe User do
       context '空の場合' do
         let(:password) { nil }
 
-        it { expect(user.errors_on(:password)).to include('can\'t be blank') }
+        it { expect(user.errors_on(:password)).to include('パスワードを入力してください') }
       end
 
       context '6文字の場合' do
         let(:password) { 'p' * 6 }
 
-        it { expect(user.errors_on(:password)).to include('is too short (minimum is 7 characters)') }
+        it { expect(user.errors_on(:password)).to include('パスワードは7文字以上で入力してください') }
       end
 
       context '7文字の場合' do
@@ -142,7 +142,7 @@ RSpec.describe User do
       context '21文字の場合' do
         let(:password) { 'p' * 21 }
 
-        it { expect(user.errors_on(:password)).to include('is too long (maximum is 20 characters)') }
+        it { expect(user.errors_on(:password)).to include('パスワードは20文字以内で入力してください') }
       end
     end
 
@@ -158,7 +158,7 @@ RSpec.describe User do
       context 'integer以外の値の場合' do
         let(:role) { '大佐' }
 
-        it { expect(user.errors_on(:role)).to include('is not a number') }
+        it { expect(user.errors_on(:role)).to include('ロールは数値で入力してください') }
       end
     end
   end

--- a/spec/requests/groups_spec.rb
+++ b/spec/requests/groups_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe 'Groups', type: :request do
       end
 
       example '適切なエラーメッセージが返されること' do
-        expect(@json['error']).to eq '指定されたIDのグループが見つかりません'
+        expect(@json['message']).to eq '指定されたIDのグループが見つかりません'
       end
     end
   end

--- a/spec/requests/passwords_spec.rb
+++ b/spec/requests/passwords_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe 'Groups', type: :request do
         end
 
         example '適切なエラーメッセージが返されること' do
-          expect(@json['error']).to eq 'パスワードが正しくありません'
+          expect(@json['message']).to eq 'パスワードが正しくありません'
         end
       end
 
@@ -82,7 +82,29 @@ RSpec.describe 'Groups', type: :request do
         end
 
         example '適切なエラーメッセージが返されること' do
-          expect(@json['error']).to eq '新しいパスワードと確認用パスワードが一致していません'
+          expect(@json['message']).to eq '新しいパスワードと確認用パスワードが一致していません'
+        end
+      end
+
+      context 'パスワードが不正な値の場合' do
+        let(:params) {{
+          password: 'password1!',
+          new_password: 'pass',
+          new_password_confirmation: 'pass'
+        }}
+
+        before do
+          patch api_passwords_path, params, env
+          @json = JSON.parse(response.body)
+        end
+
+        example '500が返ってくること' do
+          expect(response).not_to be_success
+          expect(response.status).to eq 400
+        end
+
+        example '適切なエラーメッセージが返されること' do
+          expect(@json['message']).to eq 'パスワードの更新に失敗しました'
         end
       end
     end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'Users', type: :request do
       end
 
       example '適切なエラーメッセージが返されること' do
-        expect(@json['error']).to eq 'グループidが入力されていません'
+        expect(@json['message']).to eq 'グループidが入力されていません'
       end
     end
   end
@@ -128,7 +128,7 @@ RSpec.describe 'Users', type: :request do
       end
 
       example '期待したデータが取得されていること' do
-        expect(@json['error']).to eq 'ユーザの作成に失敗しました'
+        expect(@json['message']).to eq 'ユーザーの作成に失敗しました'
       end
     end
   end
@@ -164,7 +164,7 @@ RSpec.describe 'Users', type: :request do
       end
 
       example '適切なエラーメッセージが返されること' do
-        expect(@json['error']).to eq '指定されたIDのユーザが見つかりません'
+        expect(@json['message']).to eq '指定されたIDのユーザーが見つかりません'
       end
     end
   end
@@ -239,7 +239,7 @@ RSpec.describe 'Users', type: :request do
       end
 
       example '適切なエラーメッセージが返されること' do
-        expect(@json['error']).to eq 'アカウント名かパスワードが正しくありません'
+        expect(@json['message']).to eq 'アカウント名かパスワードが正しくありません'
       end
     end
 
@@ -255,7 +255,7 @@ RSpec.describe 'Users', type: :request do
       end
 
       example '適切なエラーメッセージが返されること' do
-        expect(@json['error']).to eq 'アカウント名かパスワードが正しくありません'
+        expect(@json['message']).to eq 'アカウント名かパスワードが正しくありません'
       end
     end
   end


### PR DESCRIPTION
## やったこと

```
{
  "message": "ユーザーの作成に失敗しました",
  "errors": {
    "account": [
      "アカウント名はすでに存在します"
    ],
    "email": [
      "メールアドレスはすでに存在します"
    ]
  }
}
```

こんな感じで返すようにしました。
