### PR TITLE
emailとusernameをoptionalに

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,14 +15,12 @@ class User < ActiveRecord::Base
   # validation
   with_options unless: proc { [:oauth_registration].include?(validation_context) } do |user|
     user.validates :account,  presence: true
-    user.validates :username, presence: true
-    user.validates :email,    presence: true, format: { with: VALID_EMAIL_REGEX, allow_blank: true }
     user.validates :password, presence: true
   end
 
   validates :account,  uniqueness: true, length: {maximum: 30}
   validates :username, length: {maximum: 30}
-  validates :email, uniqueness: true, length: {maximum: 256}
+  validates :email, uniqueness: true, length: {maximum: 256}, format: { with: VALID_EMAIL_REGEX, allow_blank: true }
   validates :password, length: {minimum: 7, maximum: 20, allow_blank: true}, on: [:create, :reset_password]
   validates :role, numericality: { only_integer: true }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe User do
       context '空の場合' do
         let(:username) { nil }
 
-        it { expect(user.errors_on(:username)).to include('ユーザー名を入力してください') }
+        it { expect(user.errors_on(:username)).to be_empty }
       end
 
       context '30文字の場合' do
@@ -80,7 +80,7 @@ RSpec.describe User do
       context '空の場合' do
         let(:email) { nil }
 
-        it { expect(user.errors_on(:email)).to include('メールアドレスを入力してください') }
+        it { expect(user.errors_on(:email)).to be_empty }
       end
 
       context '重複する値の場合' do


### PR DESCRIPTION
## やったこと
- パスワード忘れた方へ、が初期リリースに間に合いそうになかったので、一旦optionalにしております。

ただ、emailを最初optionalにして、あとからmustにするとバリデーション周りで辛いので、なるはやで対応or方針決めたい
