### PR TITLE
PaymentのN+1を解消した

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,11 @@ group :development do
   gem 'capistrano-rbenv'
   gem 'capistrano-bundler'
   gem 'capistrano-passenger'
+<<<<<<< 8be8435ef7c5ed5804df35ca19b60255c8b6b3fc
   gem "turnip"
+=======
+  gem 'bullet'
+>>>>>>> bulletの導入
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -25,11 +25,8 @@ group :development do
   gem 'capistrano-rbenv'
   gem 'capistrano-bundler'
   gem 'capistrano-passenger'
-<<<<<<< 8be8435ef7c5ed5804df35ca19b60255c8b6b3fc
   gem "turnip"
-=======
   gem 'bullet'
->>>>>>> bulletの導入
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,9 @@ GEM
       tzinfo (~> 1.1)
     arel (5.0.1.20140414130214)
     builder (3.2.2)
+    bullet (5.0.0)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.9.0)
     byebug (8.2.1)
     capistrano (3.4.0)
       i18n
@@ -180,11 +183,13 @@ GEM
     uglifier (2.7.1)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    uniform_notifier (1.9.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  bullet
   byebug
   capistrano
   capistrano-bundler

--- a/app/controllers/api/group_users_controller.rb
+++ b/app/controllers/api/group_users_controller.rb
@@ -4,7 +4,7 @@ class Api::GroupUsersController < ApplicationController
   before_action :set_group_user, only: %i(accept destroy)
 
   def index
-    render json: @group.users.as_json(group_id: @group.id), status: :ok
+    render json: @group.users.includes(:totals).as_json(group_id: @group.id), status: :ok
   end
 
   def create

--- a/app/controllers/api/payments_controller.rb
+++ b/app/controllers/api/payments_controller.rb
@@ -5,7 +5,8 @@ class Api::PaymentsController < ApplicationController
   before_action :set_group, only: %i(index)
 
   def index
-    payments = @group.payments.includes(paid_user: :totals, participants: :totals)
+    payments = @group.payments.includes(paid_user: [:totals, groups: :group_users],
+      participants:  [:totals, groups: :group_users])
 
     if last_payment = Payment.unscoped.find_by(id: params[:last_id]).presence
       payments = payments.pagenate_next(last_payment)

--- a/app/controllers/api/payments_controller.rb
+++ b/app/controllers/api/payments_controller.rb
@@ -5,12 +5,14 @@ class Api::PaymentsController < ApplicationController
   before_action :set_group, only: %i(index)
 
   def index
+    payments = @group.payments.includes(paid_user: :totals, participants: :totals)
+
     if last_payment = Payment.unscoped.find_by(id: params[:last_id]).presence
-      payments = @group.payments.pagenate_next(last_payment)
+      payments = payments.pagenate_next(last_payment)
     elsif first_payment = Payment.unscoped.find_by(id: params[:first_id]).presence
-      payments = @group.payments.pagenate_prev(first_payment).reverse
+      payments = payments.pagenate_prev(first_payment).reverse
     else
-      payments = @group.payments.pagenate_next()
+      payments = payments.pagenate_next()
     end
 
     render json: payments, status: :ok

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -79,7 +79,6 @@ class User < ActiveRecord::Base
     group.group_users.each do |gu|
       if gu.user_id == self.id && gu.status == status
         result = true
-        return
       end
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,6 +32,10 @@ class User < ActiveRecord::Base
   end
 
   def as_json(options={})
+    if options[:only].present?
+      return super(except: [:password, :salt])
+    end
+
     # Groupの子として表示する際は無限Loopにならないように、Groupsを表示しない
     methods = options[:group_id].present? ? [] : %i(active_groups invited_groups)
 
@@ -62,11 +66,11 @@ class User < ActiveRecord::Base
   end
 
   def active_groups()
-    groups.includes(:group_users).where(group_users: {status: 'active'}).as_json(user_id: self.id)
+    groups.where(group_users: {status: 'active'}).as_json(user_id: self.id)
   end
 
   def invited_groups()
-    groups.includes(:group_users).where(group_users: {status: 'inviting'}).as_json(user_id: self.id)
+    groups.where(group_users: {status: 'inviting'}).as_json(user_id: self.id)
   end
 
   def oauth_registration_and_no_attribute?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,11 +66,24 @@ class User < ActiveRecord::Base
   end
 
   def active_groups()
-    groups.where(group_users: {status: 'active'}).as_json(user_id: self.id)
+    groups.select{|group| exist_group_user_with_status(group, 'active') }.as_json(user_id: self.id)
   end
 
   def invited_groups()
-    groups.where(group_users: {status: 'inviting'}).as_json(user_id: self.id)
+    groups.select{|group| exist_group_user_with_status(group, 'inviting') }.as_json(user_id: self.id)
+  end
+
+  def exist_group_user_with_status(group, status)
+    result = false
+
+    group.group_users.each do |gu|
+      if gu.user_id == self.id && gu.status == status
+        result = true
+        return
+      end
+    end
+
+    return result
   end
 
   def oauth_registration_and_no_attribute?
@@ -80,7 +93,7 @@ class User < ActiveRecord::Base
   private
 
   def include_totals(group_id)
-    group_id.present? ? totals.where(group_id: group_id) : totals
+    group_id.present? ? totals.select{|t| t.group_id == group_id} : totals
   end
 
   # パスワードを暗号化する

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,4 +34,13 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.alert = true
+    Bullet.bullet_logger = true
+    Bullet.console = true
+    Bullet.rails_logger = true
+  end
+
 end


### PR DESCRIPTION
## やったこと
- paymentのindexでN+1がでていた（本番データをローカルに持ってきて試したところSQLが309本流れてた、、、グループ複数作り出したら大変なことに、、）のでeager loadしてruby側でごにょごにょするようにした
## 懸念点
- 本質的は、いらない情報はJSONで返すべきではない（paymentでactive_groupとか取得してる）のでいつか対応したいが、jsonのkeyを変える必要とかでてきそうなのでこのPRはここまでとしたい。
- だいぶruby側で頑張ってるのでデータ量が増えてきたときにどっちが早いの？問題に直面する気がする。

とりあえずSQLは10本くらいになって、体感的にもとても速くなりました。
