### PR TITLE
エラーハンドリングでイケてなかったところの修正

### DIFF
--- a/app/controllers/api/passwords_controller.rb
+++ b/app/controllers/api/passwords_controller.rb
@@ -2,6 +2,7 @@ class Api::PasswordsController < ApplicationController
   EXPIRATION_MINUTES_FOR_RESET_PASSWORD = 30
 
   before_action :authenticate!, only: %i(update)
+  before_action :verify_params
   before_action :verify_old_password, only: %i(update)
   before_action :verify_password_confirmation, only: %i(update reset)
   before_action :set_user_by_account_and_email, only: %i(init)
@@ -36,6 +37,12 @@ class Api::PasswordsController < ApplicationController
   end
 
   private
+
+  def verify_params
+    if params[:user].blank?
+      render json: {message: "パラメータの形式が不正です"}, status: :bad_request
+    end
+  end
 
   def verify_old_password
     unless @user.authoricate(params[:user][:password].strip)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,7 +30,7 @@ class ApplicationController < ActionController::Base
     uid = request.headers[:UID]
     token = request.headers[:TOKEN]
     @user = User.find_by(id: uid)
-    if @user.present? and token == @user.token
+    if @user.present? && token == @user.token
       return true
     else
       render json: { error: "認証に失敗しました" }, status: :unauthorized

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,12 +16,12 @@ class ApplicationController < ActionController::Base
 
   def render_404(e = nil)
     logger.info "Rendering 404 with exception: #{e.message}" if e
-    render json: { error: '404 error' }, status: 404
+    render json: { message: "404 error #{e.try!(:message)}" }, status: 404
   end
 
   def render_500(e = nil)
-    logger.info "Rendering 500 with exception: #{e.message}" if e
-    render json: { error: '500 error' }, status: 500
+    logger.error "Rendering 500 with exception: #{e.message}" if e
+    render json: { message: "500 error #{e.try!(:message)}" }, status: 500
   end
 
   # 認証処理をする
@@ -33,7 +33,7 @@ class ApplicationController < ActionController::Base
     if @user.present? && token == @user.token
       return true
     else
-      render json: { error: "認証に失敗しました" }, status: :unauthorized
+      render json: { message: "認証に失敗しました" }, status: :unauthorized
       return false
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,4 +28,6 @@ Rails.application.routes.draw do
       resources :oauth_registrations, only: %i(create)
     end
   end
+
+  get '*path', controller: 'application', action: 'render_404'
 end

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -1,0 +1,62 @@
+RSpec.describe 'ApplicationController', type: :request do
+  let(:sign_in_user) { create(:user, email: 'sign-in-email@example.com', account: 'sign_in_user') }
+  let(:env) { { UID: sign_in_user.id, TOKEN: sign_in_user.token } }
+  let(:group) { create(:group, name: '幻影旅団', description: '所詮虫けらの戯言、俺の心には響かない') }
+
+  describe 'Render 404 error' do
+    context '存在しないルーティングにアクセスしようとした場合' do
+      before do
+        create(:group_user, user_id: sign_in_user.id, group_id: group.id)
+        get 'hogehoge/fugafuga', {}, env
+        @json = JSON.parse(response.body)
+      end
+
+      example '404が返ってくること' do
+        expect(response).not_to be_success
+        expect(response.status).to eq 404
+      end
+
+      example '期待したデータが取得されていること' do
+        expect(@json['message']).to eq '404 error '
+      end
+    end
+  end
+
+  describe 'authenticate' do
+    context '異常系' do
+      context 'UIDが不正の場合' do
+        before do
+          create(:group_user, user_id: sign_in_user.id, group_id: group.id)
+          get api_group_path(group), {}, { UID: sign_in_user.id + 1, TOKEN: sign_in_user.token }
+          @json = JSON.parse(response.body)
+        end
+
+        example '401が返ってくること' do
+          expect(response).not_to be_success
+          expect(response.status).to eq 401
+        end
+
+        example '期待したデータが取得されていること' do
+          expect(@json['message']).to eq '認証に失敗しました'
+        end
+      end
+
+      context 'TOKENが不正の場合' do
+        before do
+          create(:group_user, user_id: sign_in_user.id, group_id: group.id)
+          get api_group_path(group), {}, { UID: sign_in_user.id, TOKEN: sign_in_user.token + 'hoge' }
+          @json = JSON.parse(response.body)
+        end
+
+        example '401が返ってくること' do
+          expect(response).not_to be_success
+          expect(response.status).to eq 401
+        end
+
+        example '期待したデータが取得されていること' do
+          expect(@json['message']).to eq '認証に失敗しました'
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/passwords_spec.rb
+++ b/spec/requests/passwords_spec.rb
@@ -104,13 +104,35 @@ RSpec.describe 'Groups', type: :request do
           @json = JSON.parse(response.body)
         end
 
-        example '500が返ってくること' do
+        example '400が返ってくること' do
           expect(response).not_to be_success
           expect(response.status).to eq 400
         end
 
         example '適切なエラーメッセージが返されること' do
           expect(@json['message']).to eq 'パスワードの更新に失敗しました'
+        end
+      end
+
+      context 'パラメータが不正な形式の場合' do
+        let(:params) {{
+          password: 'password1!',
+          new_password: 'pass',
+          new_password_confirmation: 'pass'
+        }}
+
+        before do
+          patch api_passwords_path, params, env
+          @json = JSON.parse(response.body)
+        end
+
+        example '400が返ってくること' do
+          expect(response).not_to be_success
+          expect(response.status).to eq 400
+        end
+
+        example '適切なエラーメッセージが返されること' do
+          expect(@json['message']).to eq 'パラメータの形式が不正です'
         end
       end
     end


### PR DESCRIPTION
## やったこと
- 404や500, authenticate!など、application_controllerで処理しているところも{message: 'hogehoge'}の形にした。
- 存在しないルーティングにアクセスされた場合は404にした。
- passwordのエラー処理の一部修正
