### PR TITLE
デプロイ時に.envをコピーしてくれるような構成にした

### DIFF
--- a/lib/capistrano/tasks/copy_env.rake
+++ b/lib/capistrano/tasks/copy_env.rake
@@ -1,0 +1,9 @@
+namespace :custom do
+  task :copy_env do
+    on roles(:web) do
+      execute %[cp /var/www/html/Yoshinani/shared/.env /var/www/html/Yoshinani/current]
+    end
+  end
+
+  before 'deploy:restart', 'custom:copy_env'
+end


### PR DESCRIPTION
## やったこと
- タイトルの通りです。RAILS_ROOT/sharedに.envを置いておいて、そいつをコピーして持ってくるようにしてます。
