### PR TITLE
Oauth経由のユーザにはパスワード必須にさせたくない

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -26,13 +26,7 @@ class Api::UsersController < ApplicationController
   end
 
   def update
-    # OAuth登録直後のCSはpasswordがnilなのでupdateでハッシュ化する必要がある
-    if @user.oauth_registration_and_no_attribute?
-      @user.attributes = user_params
-      @user.hash_password
-    else
-      @user.attributes = user_params
-    end
+    @user.attributes = user_params
 
     if @user.save
       render json: @user, status: :ok

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,13 +16,12 @@ class User < ActiveRecord::Base
   # validation
   with_options unless: proc { [:oauth_registration].include?(validation_context) } do |user|
     user.validates :account,  presence: true
-    user.validates :password, presence: true
   end
 
   validates :account,  uniqueness: true, length: {maximum: 30}
   validates :username, length: {maximum: 30}
   validates :email, uniqueness: true, allow_nil: true, length: {maximum: 256}, format: { with: VALID_EMAIL_REGEX, allow_blank: true }
-  validates :password, length: {minimum: 7, maximum: 20, allow_blank: true}, on: [:create, :reset_password]
+  validates :password, presence: true, length: {minimum: 7, maximum: 20, allow_blank: true}, on: [:create, :reset_password]
   validates :role, numericality: { only_integer: true }
 
   before_create :hash_password

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,7 @@ Rails.application.routes.draw do
         end
       end
       resources :payments
-      resource :passwords, only: %i(update) do
+      resource :passwords, only: %i(create update) do
         collection do
           post :init
           patch :reset

--- a/spec/acceptance/oauth_login.feature
+++ b/spec/acceptance/oauth_login.feature
@@ -11,10 +11,14 @@
 
     かつ 'Facebook' のOAuth経由で認証を行う
     かつ 次の情報でユーザー情報の更新を行う
-      | アカウント | メールアドレス      | ユーザネーム | パスワード |
-      | fb_user    | fb_user@example.com | fb_user      | fb_user123 |
+      | アカウント | メールアドレス      | ユーザネーム |
+      | fb_user    | fb_user@example.com | fb_user     |
 
-    ならば ユーザー 'fb_user' パスワード 'fb_user123' としてログインできること
+    かつ 次の情報でパスワードの作成を行う
+      | パスワード     | 確認用パスワード |
+      | password1234 | password1234  |
+
+    ならば ユーザー 'fb_user' パスワード 'password1234' としてログインできること
 
   シナリオ: OAuth登録をした後、OAuthログインを行う
     前提 次のSNSが登録されている:

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -4,5 +4,10 @@ FactoryGirl.define do
     password 'password1!'
     email 'ganbaruhito@example.com'
     username 'ganbaruhito'
+
+    # save時にvalidationをスキップする
+    to_create do |instance|
+      instance.save validate: false
+    end 
   end
 end

--- a/spec/steps/password_steps.rb
+++ b/spec/steps/password_steps.rb
@@ -1,0 +1,10 @@
+step '次の情報でパスワードの作成を行う' do |table|
+
+  params = { user:{} }
+  table.hashes.each do |row|
+    params[:user][:new_password]  = row['パスワード']     if row['パスワード']
+    params[:user][:new_password_confirmation]    = row['確認用パスワード'] if row['確認用パスワード']
+  end
+
+  post api_passwords_path, params, { UID: @user['id'], TOKEN: @user['token'] }
+end


### PR DESCRIPTION
## やったこと
- userのcreate、password_controllerから呼ばれたときのみ、passwordを必須とした
- passwordがnilのUserがpasswordを新規で作成できるようにした
  https://github.com/Mikazukittp/yoshinani/wiki/API-wiki#passwords-collections
- テスト書いた
